### PR TITLE
Add devcontainer configuration with Java 8 and Maven support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "Dev Container (1-8-jdk-bullseye)",
+    "image": "mcr.microsoft.com/devcontainers/java:1-8-jdk-bullseye",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-java-pack"
+            ]
+        }
+    },
+    "postCreateCommand": "java -version"
+}


### PR DESCRIPTION
This pull request adds a new development container configuration to the project, making it easier for developers to set up a consistent Java development environment using VS Code and Docker.

Development environment setup:

* Added a `.devcontainer/devcontainer.json` file that specifies a Java 8 development container image, includes Maven, and recommends relevant VS Code extensions for Java development.Also added vscode recommended extensions for Java development.